### PR TITLE
Arduino nano esp32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RF CTF Fox code
 |M5Stack Atom-lite |✅|✅|✅|
 |M5Stack AtomS3-lite |✅|❌|✅|
 |M5Stack StampS3 |✅|❌|✅|
+|Arduino Nano ESP32 |✅|❌|✅|
 
 We will accept PRs to extend support to other platformio supported hardware.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ RF CTF Fox code
 |M5Stack AtomS3-lite |✅|❌|✅|
 |M5Stack StampS3 |✅|❌|✅|
 |Arduino Nano ESP32 |✅|❌|✅|
+|Seeed XIAO ESP32C5 |🚧|🚧|✅|
 
 We will accept PRs to extend support to other platformio supported hardware.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ RF CTF Fox code
 |M5Stack AtomS3-lite |✅|❌|✅|
 |M5Stack StampS3 |✅|❌|✅|
 |Arduino Nano ESP32 |✅|❌|✅|
-|Seeed XIAO ESP32C5 |🚧|🚧|✅|
 
 We will accept PRs to extend support to other platformio supported hardware.
 

--- a/bluetooth/classic_discoverable/platformio.ini
+++ b/bluetooth/classic_discoverable/platformio.ini
@@ -32,6 +32,10 @@ board = m5stack-atoms3
 [m5stamps3]
 ; no bt classic, unsupported
 board = m5stack-stamps3
+[arduino_nano_esp32]
+; no bt classic, unsupported
+board = arduino_nano_esp32
+
 
 ; actual targets, two per board
 [env:m5atom-easy]
@@ -40,3 +44,4 @@ build_flags = ${difficulty.easy}
 [env:m5atom-hard]
 extends = m5atom, hard
 build_flags = ${difficulty.hard}
+

--- a/bluetooth/classic_discoverable/platformio.ini
+++ b/bluetooth/classic_discoverable/platformio.ini
@@ -33,7 +33,7 @@ board = m5stack-atoms3
 ; no bt classic, unsupported
 board = m5stack-stamps3
 [arduino_nano_esp32]
-; no bt classic, unsupported
+;unsure if this works yet
 board = arduino_nano_esp32
 
 

--- a/bluetooth/classic_discoverable/platformio.ini
+++ b/bluetooth/classic_discoverable/platformio.ini
@@ -33,7 +33,7 @@ board = m5stack-atoms3
 ; no bt classic, unsupported
 board = m5stack-stamps3
 [arduino_nano_esp32]
-;unsure if this works yet
+; no bt classic, unsupported
 board = arduino_nano_esp32
 
 

--- a/bluetooth/iBeacon/platformio.ini
+++ b/bluetooth/iBeacon/platformio.ini
@@ -33,6 +33,9 @@ board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
 [m5stamps3]
 board = m5stack-stamps3
 board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
+[arduino_nano_esp32]
+board = arduino_nano_esp32
+board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
 
 ; actual targets, three per board
 [env:m5atom-easy]
@@ -64,3 +67,13 @@ build_flags = ${m5stamps3.board_flags} ${difficulty.medium}
 [env:m5stamps3-hard]
 extends = m5stamps3
 build_flags = ${m5stamps3.board_flags} ${difficulty.hard}
+
+[env:arduino_nano_esp32-easy]
+extends = arduino_nano_esp32
+build_flags = ${arduino_nano_esp32.board_flags} ${difficulty.easy}
+[env:arduino_nano_esp32-medium]
+extends = arduino_nano_esp32
+build_flags = ${arduino_nano_esp32.board_flags} ${difficulty.medium}
+[env:arduino_nano_esp32-hard]
+extends = arduino_nano_esp32
+build_flags = ${arduino_nano_esp32.board_flags} ${difficulty.hard}

--- a/include/rfhsbt.h
+++ b/include/rfhsbt.h
@@ -1,12 +1,12 @@
 uint8_t mac_addr[6] = MAC_ADDR;
 
 void rfhssetbtmac() {
-  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#mac-address
 
 #if defined(ARDUINO_NANO_ESP32)
   mac_addr[5] -= 1;
 
 #else
+ // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#mac-address
   mac_addr[5] -= 2;
 
 #endif

--- a/include/rfhsbt.h
+++ b/include/rfhsbt.h
@@ -2,6 +2,14 @@ uint8_t mac_addr[6] = MAC_ADDR;
 
 void rfhssetbtmac() {
   // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#mac-address
+
+#if defined(ARDUINO_NANO_ESP32)
+  mac_addr[5] -= 1;
+
+#else
   mac_addr[5] -= 2;
+
+#endif
   esp_base_mac_addr_set(mac_addr);
+
 }

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -56,7 +56,6 @@ void rfhsledinit() {
 
 // Basically do nothing. The colors are set in ledcolor()
 
-// #elif defined(ARDUINO_XIAO_ESP32C5)
   // Single yellow LED on GPIO 27 as output
   // pinMode(27, OUTPUT);
 

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -1,8 +1,8 @@
 #include <FastLED.h>
 
-#define NUM_LEDS 1
+const uint8_t ESP32_MAX_BRIGHTNESS = 20;
 
-#define ESP32_MAX_BRIGHTNESS 20
+#define NUM_LEDS 1
 
 #if defined(ARDUINO_M5Stack_ATOM)
 #define DATA_PIN 27
@@ -38,11 +38,6 @@ void ledcolor(uint32_t colorcode) {
   analogWrite(LED_GREEN, 255 - leds[0].g);
   analogWrite(LED_BLUE,  255 - leds[0].b);
 
-// #elif defined(ARDUINO_XIAO_ESP32C5)
-  // No RGB LED, just a single yellow USER_LED.
-  // The light is ON when ap is initializing and active
-  // OFF when going to sleep.
-  // digitalWrite(27, LOW);
 
 #else
 

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -3,7 +3,7 @@
 
 #define NUM_LEDS 1
 
-#define ESP32_MAX_BRIGHTNESS 50
+#define ESP32_MAX_BRIGHTNESS 20
 
 #if defined(ARDUINO_M5Stack_ATOM)
 #define DATA_PIN 27
@@ -20,6 +20,13 @@ CRGB leds[NUM_LEDS];
 
 void ledcolor(uint32_t colorcode) {
 
+   /*
+   * What if we had more than 1 led?
+   * for(int num=0; num<NUM_LEDS; num++) {
+   *  leds[num] = CRGB(colorcode);
+   * }
+   */
+
   leds[0] = CRGB(colorcode);
 
 #if defined(ARDUINO_NANO_ESP32)
@@ -32,7 +39,7 @@ void ledcolor(uint32_t colorcode) {
   analogWrite(LED_GREEN, 255 - leds[0].g);
   analogWrite(LED_BLUE,  255 - leds[0].b);
 
-#elif defined(ARDUINO_XIAO_ESP32C5)
+// #elif defined(ARDUINO_XIAO_ESP32C5)
   // No RGB LED, just a single yellow USER_LED.
   // The light is ON when ap is initializing and active
   // OFF when going to sleep.
@@ -42,6 +49,10 @@ void ledcolor(uint32_t colorcode) {
 
   // For any digital LED
   FastLED.show();
+
+  // We are supposed to wait this long but I don't want to.
+  // delay(50)
+
 #endif
 }
 

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -1,5 +1,4 @@
 #include <FastLED.h>
-#include <Arduino.h>
 
 #define NUM_LEDS 1
 

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -62,7 +62,7 @@ void rfhsledinit() {
 
 // Basically do nothing. The colors are set in ledcolor()
 
-#elif defined(ARDUINO_XIAO_ESP32C5)
+// #elif defined(ARDUINO_XIAO_ESP32C5)
   // Single yellow LED on GPIO 27 as output
   // pinMode(27, OUTPUT);
 

--- a/include/rfhsledmacros.h
+++ b/include/rfhsledmacros.h
@@ -1,6 +1,9 @@
 #include <FastLED.h>
+#include <Arduino.h>
 
 #define NUM_LEDS 1
+
+#define ESP32_MAX_BRIGHTNESS 50
 
 #if defined(ARDUINO_M5Stack_ATOM)
 #define DATA_PIN 27
@@ -10,29 +13,54 @@
 #define DATA_PIN 19
 #elif defined(ARDUINO_M5Stack_StampS3)
 #define DATA_PIN 21
+
 #endif
 
 CRGB leds[NUM_LEDS];
 
 void ledcolor(uint32_t colorcode) {
-  /*
-   * What if we had more than 1 led?
-   * for(int num=0; num<NUM_LEDS; num++) {
-   *  leds[num] = CRGB(colorcode);
-   * }
-   */
 
   leds[0] = CRGB(colorcode);
+
+#if defined(ARDUINO_NANO_ESP32)
+
+  //Adjusting Brightness
+  leds[0].nscale8(ESP32_MAX_BRIGHTNESS);
+
+  //Displaying the color on the board
+  analogWrite(LED_RED,   255 - leds[0].r);
+  analogWrite(LED_GREEN, 255 - leds[0].g);
+  analogWrite(LED_BLUE,  255 - leds[0].b);
+
+#elif defined(ARDUINO_XIAO_ESP32C5)
+  // No RGB LED, just a single yellow USER_LED.
+  // The light is ON when ap is initializing and active
+  // OFF when going to sleep.
+  // digitalWrite(27, LOW);
+
+#else
+
+  // For any digital LED
   FastLED.show();
-  // We are supposed to wait this long but I don't want to.
-  // delay(50)
+#endif
 }
 
 void rfhsledinit() {
+
+#if defined(ARDUINO_NANO_ESP32)
+
+// Basically do nothing. The colors are set in ledcolor()
+
+#elif defined(ARDUINO_XIAO_ESP32C5)
+  // Single yellow LED on GPIO 27 as output
+  // pinMode(27, OUTPUT);
+
+#else
   FastLED.addLeds<WS2812, DATA_PIN, GRB>(leds, NUM_LEDS);
   // M5Stack recommends not setting this value greater than 20
   // to avoid melting the screen/cover over the LEDs
   FastLED.setBrightness(20);
+#endif
   // Set a color so we know the leds have been initialized
   ledcolor(0x9400D3);  // DARKVIOLET
 }

--- a/wifi/wifi_ap_client/platformio.ini
+++ b/wifi/wifi_ap_client/platformio.ini
@@ -40,7 +40,6 @@ board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
 [arduino_nano_esp32]
 board= arduino_nano_esp32
 board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
-#build_flags = -DFASTLED_ESP32_LCD_RGB=1
 
 ; actual targets, four per board
 [env:m5atom-easy-ap]

--- a/wifi/wifi_ap_client/platformio.ini
+++ b/wifi/wifi_ap_client/platformio.ini
@@ -37,6 +37,10 @@ board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
 [m5stamps3]
 board = m5stack-stamps3
 board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
+[arduino_nano_esp32]
+board= arduino_nano_esp32
+board_flags = -DARDUINO_USB_CDC_ON_BOOT=1
+#build_flags = -DFASTLED_ESP32_LCD_RGB=1
 
 ; actual targets, four per board
 [env:m5atom-easy-ap]
@@ -51,6 +55,20 @@ build_flags = ${difficulty.hard} ${mode.ap}
 [env:m5atom-hard-client]
 extends = m5atom
 build_flags = ${difficulty.hard} ${mode.client}
+[env:arduino_nano_esp32-easy-ap]
+extends = arduino_nano_esp32
+build_flags = ${difficulty.easy} ${mode.ap} ${arduino_nano_esp32.board_flags}
+[env:arduino_nano_esp32-easy-client]
+extends = arduino_nano_esp32
+build_flags = ${difficulty.easy} ${mode.client} ${arduino_nano_esp32.board_flags}
+[env:arduino_nano_esp32-hard-ap]
+extends = arduino_nano_esp32
+build_flags = ${difficulty.hard} ${mode.ap} ${arduino_nano_esp32.board_flags}
+[env:arduino_nano_esp32-hard-client]
+extends = arduino_nano_esp32
+build_flags = ${difficulty.hard} ${mode.client} ${arduino_nano_esp32.board_flags} 
+
+
 
 ; known issues:
 ; serial isn't working

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -16,7 +16,7 @@ void setup() {
   esp_wifi_init(&cfg);
   esp_wifi_set_storage(WIFI_STORAGE_RAM);
   delay(100); // adjust the esp_deep_sleep if you change this
-  esp_wifi_start();
+  // esp_wifi_start(); // esp_wifi_set_mac() only requires Wi-Fi to be *initialized*
 
   #if defined(AP)
   // Create Wi-Fi network with SSID and password
@@ -35,12 +35,6 @@ void setup() {
   } else {
     Serial.println("Error setting MAC address");
   }
-#if defined(ARDUINO_NANO_ESP32)
-  // esp_wifi_start() returns an error when called while already
-  // running, so WiFiStart() fails and WiFi.mode()/softAP()
-  // never properly start the AP => The AP name shows up as ESP-33XXXX.
-  esp_wifi_stop();
-#endif
 
   // Before this desired mac address is not set
   // Speed counts

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -75,8 +75,8 @@ void setup() {
   disableWiFi();
   ledcolor(0xff0000);  // RED
   delay(75)// adjust the esp_deep_sleep if you change this
-  // subtract sleep time on line 20 and 78
-  int64_t sleepy_tyme = (int64_t)uS_TO_S * TIME_TO_SLEEP - (75 * 1000) - (100 * 1000);
+  // subtract sleep time on line 39 and 105
+  int sleepy_tyme = uS_TO_S * TIME_TO_SLEEP - 75 - 1000;
   if (sleepy_tyme < 0 ) {
     sleepy_tyme = 0;
   }

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -74,9 +74,9 @@ void setup() {
   ledcolor(0x880000);  // HALF RED
   disableWiFi();
   ledcolor(0xff0000);  // RED
-  delay(2000);  // adjust the esp_deep_sleep if you change this
+  delay(75)// adjust the esp_deep_sleep if you change this
   // subtract sleep time on line 20 and 78
-  int64_t sleepy_tyme = (int64_t)uS_TO_S * TIME_TO_SLEEP - (2000 * 1000) - (100 * 1000);
+  int64_t sleepy_tyme = (int64_t)uS_TO_S * TIME_TO_SLEEP - (75 * 1000) - (100 * 1000);
   if (sleepy_tyme < 0 ) {
     sleepy_tyme = 0;
   }

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -35,6 +35,13 @@ void setup() {
   } else {
     Serial.println("Error setting MAC address");
   }
+#if defined(ARDUINO_NANO_ESP32)
+  // esp_wifi_start() returns an error when called while already
+  // running, so WiFiStart() fails and WiFi.mode()/softAP()
+  // never properly start the AP => The AP name shows up as ESP-33XXXX.
+  esp_wifi_stop();
+#endif
+
   // Before this desired mac address is not set
   // Speed counts
 

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -68,15 +68,15 @@ void setup() {
   // Before this desired config is not set
   // Speed counts
   Serial.println("Awake and screaming");
-  
+
   delay(TIME_TO_WAKE * mS_TO_S);
   Serial.println("Going to sleep");
   ledcolor(0x880000);  // HALF RED
   disableWiFi();
   ledcolor(0xff0000);  // RED
-  delay(75);  // adjust the esp_deep_sleep if you change this
-  // subtract sleep time on line 39 and 105
-  int sleepy_tyme = uS_TO_S * TIME_TO_SLEEP - 75 - 100;
+  delay(2000);  // adjust the esp_deep_sleep if you change this
+  // subtract sleep time on line 20 and 78
+  int64_t sleepy_tyme = (int64_t)uS_TO_S * TIME_TO_SLEEP - (2000 * 1000) - (100 * 1000);
   if (sleepy_tyme < 0 ) {
     sleepy_tyme = 0;
   }

--- a/wifi/wifi_ap_client/src/main.cpp
+++ b/wifi/wifi_ap_client/src/main.cpp
@@ -74,9 +74,9 @@ void setup() {
   ledcolor(0x880000);  // HALF RED
   disableWiFi();
   ledcolor(0xff0000);  // RED
-  delay(75)// adjust the esp_deep_sleep if you change this
+  delay(75); // adjust the esp_deep_sleep if you change this
   // subtract sleep time on line 39 and 105
-  int sleepy_tyme = uS_TO_S * TIME_TO_SLEEP - 75 - 1000;
+  int sleepy_tyme = uS_TO_S * TIME_TO_SLEEP - 75 - 100;
   if (sleepy_tyme < 0 ) {
     sleepy_tyme = 0;
   }


### PR DESCRIPTION
Added support for the arduino nano esp32. The board uses an analog RGB LED rather than the digital LED used by the M5Stack boards, which explains the handling with analogWrite().

Adding a generic Analog_LED define, so any board with an analog LED would be directly supported sounds like a cool idea.